### PR TITLE
Replace deprecated `TablePrinter`

### DIFF
--- a/milestone/internal/milestone/display.go
+++ b/milestone/internal/milestone/display.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/417-72KI/gh-milestone/milestone/internal/utils"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/pkg/markdown"
-	"github.com/cli/cli/v2/utils"
 	"github.com/cli/go-gh/v2/pkg/text"
 	"github.com/google/go-github/v56/github"
 )

--- a/milestone/internal/utils/table_printer.go
+++ b/milestone/internal/utils/table_printer.go
@@ -1,0 +1,87 @@
+package utils
+
+import (
+	"io"
+	"strings"
+
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/go-gh/v2/pkg/tableprinter"
+)
+
+type TablePrinter interface {
+	IsTTY() bool
+	AddField(string, func(int, string) string, func(string) string)
+	EndRow()
+	Render() error
+}
+
+type TablePrinterOptions struct {
+	IsTTY    bool
+	MaxWidth int
+	Out      io.Writer
+}
+
+func NewTablePrinter(io *iostreams.IOStreams) TablePrinter {
+	return NewTablePrinterWithOptions(io, TablePrinterOptions{
+		IsTTY: io.IsStdoutTTY(),
+	})
+}
+
+func NewTablePrinterWithOptions(ios *iostreams.IOStreams, opts TablePrinterOptions) TablePrinter {
+	var out io.Writer
+	if opts.Out != nil {
+		out = opts.Out
+	} else {
+		out = ios.Out
+	}
+	var maxWidth int
+	if opts.IsTTY {
+		if opts.MaxWidth > 0 {
+			maxWidth = opts.MaxWidth
+		} else {
+			maxWidth = ios.TerminalWidth()
+		}
+	}
+	tp := tableprinter.New(out, opts.IsTTY, maxWidth)
+	return &printer{
+		tp:    tp,
+		isTTY: opts.IsTTY,
+	}
+}
+
+type printer struct {
+	tp       tableprinter.TablePrinter
+	colIndex int
+	isTTY    bool
+}
+
+func (p printer) IsTTY() bool {
+	return p.isTTY
+}
+
+func (p *printer) AddField(s string, truncateFunc func(int, string) string, colorFunc func(string) string) {
+	if truncateFunc == nil {
+		// Disallow ever truncating the 1st column or any URL value
+		if p.colIndex == 0 || isURL(s) {
+			p.tp.AddField(s, tableprinter.WithTruncate(nil), tableprinter.WithColor(colorFunc))
+		} else {
+			p.tp.AddField(s, tableprinter.WithColor(colorFunc))
+		}
+	} else {
+		p.tp.AddField(s, tableprinter.WithTruncate(truncateFunc), tableprinter.WithColor(colorFunc))
+	}
+	p.colIndex++
+}
+
+func (p *printer) EndRow() {
+	p.tp.EndRow()
+	p.colIndex = 0
+}
+
+func (p *printer) Render() error {
+	return p.tp.Render()
+}
+
+func isURL(s string) bool {
+	return strings.HasPrefix(s, "https://") || strings.HasPrefix(s, "http://")
+}


### PR DESCRIPTION
`github.com/cli/cli/v2/utils.TablePrinter` has been removed on [`v2.38.0`](https://github.com/cli/cli/compare/v2.37.0...v2.38.0#diff-37dfbfed05eabd24eeac20a54df515a5db6d59f1ee5276caaf7e5957d810185f)